### PR TITLE
Updated Minimum Package handling

### DIFF
--- a/tasks/RedHat/installation.yml
+++ b/tasks/RedHat/installation.yml
@@ -122,7 +122,8 @@
       yum:
              name: "{{  sap_hana_preconfigure_fact_minpkglist }}"
              state: present
-      when: ( sap_hana_preconfigure_fact_minpkglist is none)  or ( sap_hana_preconfigure_fact_minpkglist | trim == '' )
+      when: not ( sap_hana_preconfigure_fact_minpkglist == [ "" ] )
+
   when: 
     - sap_hana_preconfigure_min_package_check|bool
     - not( (sap_hana_preconfigure_min_pkgs is undefined) or (sap_hana_preconfigure_min_pkgs is none) or (sap_hana_preconfigure_min_pkgs | trim == '') ) 

--- a/tasks/RedHat/installation.yml
+++ b/tasks/RedHat/installation.yml
@@ -14,12 +14,28 @@
 #    verbosity: "{{ debuglevel }}"
 #
 # Minimum supported Supported Kernel versions and patches to use with certified Hardware for SAP HANA on RHEL 7
-#  TODO: use jinja function version (version_compare) -> ansible user guide
 
-- name: ensure minimal required packages are installed
-  package:
-    state: present
-    name: "{{ sap_hana_preconfigure_min_pkgs }}"
+- name: ensure minimum packages are installed
+  block:
+    - name: check if minimum release needs to be installed
+      shell: |
+             set -x
+             required_pkg={{ pkg | join('-') }}
+             newest=$(echo -e "$required_pkg\n$(rpm -qa | grep {{ pkg[0] }} )"| sort -V | tail -1)
+             if [ $newest == $required_pkg ]; then
+                echo $newest
+             fi
+      loop: "{{ sap_hana_preconfigure_min_pkgs }}"
+      loop_control:
+               loop_var: pkg
+      register: sap_hana_preconfigure_register_minpkglist
+      changed_when: false
+
+    - name: Install minimum packages if required
+      yum:
+             name: "{{ item.stdout }}"
+             state: present
+      with_items: "{{ sap_hana_preconfigure_register_minpkglist.results }}"
   when: 
     - sap_hana_preconfigure_min_package_check|bool
     - not( (sap_hana_preconfigure_min_pkgs is undefined) or (sap_hana_preconfigure_min_pkgs is none) or (sap_hana_preconfigure_min_pkgs | trim == '') ) 

--- a/tasks/RedHat/installation.yml
+++ b/tasks/RedHat/installation.yml
@@ -112,7 +112,7 @@
 
     - name: Create list of packages to be installed
       set_fact:
-        sap_hana_preconfigure_fact_minpkglist: "{{ sap_hana_preconfigure_fact_minpkglist + [ pkg.stdout ] }}"
+        sap_hana_preconfigure_fact_minpkglist: "{{ sap_hana_preconfigure_fact_minpkglist | difference(['']) + [ pkg.stdout ] }}"
       loop: "{{ sap_hana_preconfigure_register_minpkglist.results }}"
       loop_control:
                loop_var: pkg

--- a/tasks/RedHat/installation.yml
+++ b/tasks/RedHat/installation.yml
@@ -13,33 +13,6 @@
 #  debug:
 #    verbosity: "{{ debuglevel }}"
 #
-# Minimum supported Supported Kernel versions and patches to use with certified Hardware for SAP HANA on RHEL 7
-
-- name: ensure minimum packages are installed
-  block:
-    - name: check if minimum release needs to be installed
-      shell: |
-             set -x
-             required_pkg={{ pkg | join('-') }}
-             newest=$(echo -e "$required_pkg\n$(rpm -qa | grep {{ pkg[0] }} )"| sort -V | tail -1)
-             if [ $newest == $required_pkg ]; then
-                echo $newest
-             fi
-      loop: "{{ sap_hana_preconfigure_min_pkgs }}"
-      loop_control:
-               loop_var: pkg
-      register: sap_hana_preconfigure_register_minpkglist
-      changed_when: false
-
-    - name: Install minimum packages if required
-      yum:
-             name: "{{ item.stdout }}"
-             state: present
-      with_items: "{{ sap_hana_preconfigure_register_minpkglist.results }}"
-  when: 
-    - sap_hana_preconfigure_min_package_check|bool
-    - not( (sap_hana_preconfigure_min_pkgs is undefined) or (sap_hana_preconfigure_min_pkgs is none) or (sap_hana_preconfigure_min_pkgs | trim == '') ) 
-
 - name: ensure required packagegroups are installed
   package: 
     state: present 
@@ -112,5 +85,35 @@
         local_action: wait_for host={{ inventory_hostname }} port=22 state=started delay=90 sleep=2 timeout={{ sap_hana_preconfigure_reboot_timeout }}
         become: false
   when: sap_hana_preconfigure_reboot_after_update == true and sap_hana_preconfigure_register_reboot_required.rc == 1
+
+### At this point the system should be updated and installed accordingly. 
+### We now check that the irequired minimum releases of the current target OS have been installed
+# Minimum supported Supported Kernel versions and patches to use with certified Hardware for SAP HANA on RHEL 7
+
+- name: ensure minimum packages are installed
+  block:
+    - name: check if minimum release needs to be installed
+      shell: |
+             set -x
+             required_pkg={{ pkg | join('-') }}
+             newest=$(echo -e "$required_pkg\n$(rpm -q {{ pkg[0] }} )"| sort -V | tail -1)
+             if [ $newest == $required_pkg ]; then
+                echo $newest
+             fi
+      loop: "{{ sap_hana_preconfigure_min_pkgs }}"
+      loop_control:
+               loop_var: pkg
+      register: sap_hana_preconfigure_register_minpkglist
+      changed_when: false
+
+    - name: Install minimum packages if required
+      yum:
+             name: "{{ item.stdout }}"
+             state: present
+      with_items: "{{ sap_hana_preconfigure_register_minpkglist.results }}"
+  when: 
+    - sap_hana_preconfigure_min_package_check|bool
+    - not( (sap_hana_preconfigure_min_pkgs is undefined) or (sap_hana_preconfigure_min_pkgs is none) or (sap_hana_preconfigure_min_pkgs | trim == '') ) 
+
 
 ...

--- a/tasks/RedHat/installation.yml
+++ b/tasks/RedHat/installation.yml
@@ -106,14 +106,25 @@
       register: sap_hana_preconfigure_register_minpkglist
       changed_when: false
 
+    - name: Initialize an empty list for our strings
+      set_fact:
+        sap_hana_preconfigure_fact_minpkglist: []
+
+    - name: Create list of packages to be installed
+      set_fact:
+        sap_hana_preconfigure_fact_minpkglist: "{{ sap_hana_preconfigure_fact_minpkglist + [ pkg.stdout ] }}"
+      loop: "{{ sap_hana_preconfigure_register_minpkglist.results }}"
+      loop_control:
+               loop_var: pkg
+    - debug: var=sap_hana_preconfigure_fact_minpkglist
+
     - name: Install minimum packages if required
       yum:
-             name: "{{ item.stdout }}"
+             name: "{{  sap_hana_preconfigure_fact_minpkglist }}"
              state: present
-      with_items: "{{ sap_hana_preconfigure_register_minpkglist.results }}"
+      when: ( sap_hana_preconfigure_fact_minpkglist is none)  or ( sap_hana_preconfigure_fact_minpkglist | trim == '' )
   when: 
     - sap_hana_preconfigure_min_package_check|bool
     - not( (sap_hana_preconfigure_min_pkgs is undefined) or (sap_hana_preconfigure_min_pkgs is none) or (sap_hana_preconfigure_min_pkgs | trim == '') ) 
-
 
 ...

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -39,26 +39,25 @@ sap_hana_preconfigure_required_ppc64le:
 # The following will assign them properly to sap_hana_preconfigure_min_packages. If you do not define a variable sap_hana_preconfigure_min_packages_VERSION, sap_hana_preconfigure_min_packages keeps undefined as well
 
 sap_hana_preconfigure_min_packages_7.2:
-  - kernel-3.10.0-327.62.4.el7 
-  - systemd-219-19.el7_2.4
+        - [ 'kernel' , '3.10.0-327.62.4.el7' ]
+        - [ 'systemd' , '219-19.el7_2.4' ]
 
 sap_hana_preconfigure_min_packages_7.3:
-  - kernel-3.10.0-514.36.5.el7
-  - glibc-2.17-157.el7_3.5
-  - tuned-profiles-sap-hana-2.7.1-3.el7_3.3
+        - [ 'kernel' , '3.10.0-514.36.5.el7' ]
+        - [ 'glibc' , '2.17-157.el7_3.5' ]
+        - [ 'tuned-profiles-sap-hana' , '2.7.1-3.el7_3.3' ]
 
 sap_hana_preconfigure_min_packages_7.4:
-  - kernel-3.10.0-693.11.6.el7
-  - tuned-profiles-sap-hana-2.8.0-5.el7_4.2
+        - [ 'kernel' , '3.10.0-693.11.6.el7' ]
+        - [ 'tuned-profiles-sap-hana' , '2.8.0-5.el7_4.2' ]
 
 ## New requirement for TCPSACK fix SAPNOTE 2812427
 sap_hana_preconfigure_min_packages_7.5:
-  - kernel-3.10.0-862.41.1.el7
+        - [ 'kernel' , '3.10.0-862.41.1.el7' ]
 
 ## New requirement for TCPSACK fix SAPNOTE 2812427
 sap_hana_preconfigure_min_packages_7.6:
-  # kernel-3.10.0-957.1.3.el7
-  - kernel-3.10.0-957.27.4.el7
+        - [ 'kernel' , '3.10.0-957.27.4.el7' ]
 
 sap_hana_preconfigure_min_packages_7.7:
 


### PR DESCRIPTION
The minimum package comparison was a bad hack before. The  code is now changed and working. The minimum packages are checked AFTER a possible  update has been made.
If the installed packages are newer than the required everything is fine and nothing will be done. Otherwise the min release is tries to install the required min release. 
The playbook fails when the min packages are not available
Known Bug: The min packages are set wrong, if the update lifts the minor release of the os. 
Maybe we need to rerun gather_facts and reread variables after OS update!