### PR TITLE
Fixes #56 add rhui naming sheme to repositories

### DIFF
--- a/tasks/sapnote/2009879.yml
+++ b/tasks/sapnote/2009879.yml
@@ -11,8 +11,8 @@
   shell: |
     yum repolist | awk '
        BEGIN {a=0} 
-       /rhel-{{ ansible_distribution_major_version }}-server-e[4u]s-rpms/ {a++} 
-       /rhel-sap-hana-for-rhel-{{ ansible_distribution_major_version }}-server-e[4u]s-rpms/ {a++} 
+       /rhel-{{ ansible_distribution_major_version }}-server-(rhui-)?e[4u]s-rpms/ {a++} 
+       /rhel-sap-hana-for-rhel-{{ ansible_distribution_major_version }}-server-(rhui-)?e[4u]s-rpms/ {a++} 
        END {print a}'
   register: sap_hana_preconfigure_register_eus
   changed_when: false


### PR DESCRIPTION
repos in azure are named like this:
rhui-rhel-7-server-rhui-eus-rpms
rhel-sap-for-rhel-7-server-eus-rhui-rpms
rhui-sap-hana-for-rhel-7-server-eus-rpms

notice the inconsistency in naming ... :) the 2nd rhui change is not strictly speaking needed but I added it in case they start naming them like the standard rhel repos with the 2nd rhui before eus....