### PR TITLE
Change referenced Ansible Roles to the new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To get a personal developer edition of RHEL for SAP solutions, please register a
 For supported RHEL releases [click here](https://access.redhat.com/solutions/2479121)
 
 It is also important that your disks are setup according to the [SAP storage requirements for SAP HANA](https://www.sap.com/documents/2015/03/74cdb554-5a7c-0010-8F2c7-eda71af511fa.html). This [BLOG](https://blogs.sap.com/2017/03/07/the-ultimate-guide-to-effective-sizing-of-sap-hana/) is also quite helpful when sizing HANA systems.
-You can use the [disk-init](https://galaxy.ansible.com/mk-ansible-roles/disk-init/) role to automate this process
+You can use the [storage](https://galaxy.ansible.com/linux-system-roles/storage) role to automate this process
 
 If you want to use this system in production make sure time service is configured correctly. You can use [rhel-system-roles](https://access.redhat.com/articles/3050101) to automate this
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ for RHEL 8.x:
 
 
 For details, see the Red Hat knowledge base article: [How to subscribe SAP HANA systems to the Update Services for SAP Solutions](https://access.redhat.com/solutions/3075991))
-You can use the [subscribe-rhn](https://galaxy.ansible.com/mk-ansible-roles/subscribe-rhn/) role to automate this process
+You can use the [sap-rhsm](https://galaxy.ansible.com/redhat_sap/sap_rhsm) role to automate this process
 
 To install HANA on Red Hat Enterprise Linux 6, 7, or 8, you need some additional packages
 which come in a special repository. To get this repository you need to have one
@@ -181,7 +181,7 @@ Here is an example playbook that prepares a server for hana installation.
           # rhel-system-roles.timesync variables
 
   roles:
-        - { role: mk-ansible-roles.subscribe-rhn }
+        - { role: redhat_sap.sap_rhsm }
         - { role: linux-system-roles.sap-base-settings }
         - { role: linux-system-roles.sap-hana-preconfigure }
 ```


### PR DESCRIPTION
SAP related community roles have been moved to 'https://github.com/redhat-sap/' which means existing references to previuos repositories or Galaxy roles need to be updated as this case.