### PR TITLE
fixes for issues #109...114; 116

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ If you want the role to set the RHEL release to a certain fixed minor release (a
 sap_hana_preconfigure_set_minor_release
 ```
 
+### Add the repository for IBM service and productivity tools for POWER (ppc64le only)
+In case you do *not* want to automatically add the repository for the IBM service and productivity tools, set the following variable to `no`. Default is `yes`, meaning that the role will download and install the package specified in variable sap_hana_preconfigure_ibm_power_repo_url (see below) and also run the command /opt/ibm/lop/configure to accept the license.
+```yaml
+sap_hana_preconfigure_add_ibm_power_repo
+```
+
 ### URL for IBM service and productivity tools for POWER (ppc64le only)
 The following variable is set to the location of package ibm-power-repo-lastest.noarch.rpm or a package with similar contents, as defined by variable __sap_hana_preconfigure_ibm_power_repo_url in vars/RedHat_7.yml and vars/RedHat_8.yml.
 You can replace it by your own URL by setting this variable to a different URL.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ Note
 ----
 For finding out which SAP notes will be used by this role, please check the contents of variable `__sap_hana_preconfigure_sapnotes` in files `vars/*.yml` (choose the file which matches your OS distribution and version).
 
-Before running this role on a RHEL on ppc64le system, make sure that you have access to the required IBM repos/packages as mentioned in the comments to variable `__sap_hana_preconfigure_required_ppc64le`, see files `vars/*.yml`.
-
 Do not run this role against an SAP HANA or other production system. The role will enforce a certain configuration on the managed node(s), which might not be intended.
 
 Role Variables

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ If you want the role to set the RHEL release to a certain fixed minor release (a
 sap_hana_preconfigure_set_minor_release
 ```
 
+### URL for IBM service and productivity tools for POWER (ppc64le only)
+The following variable is set to the location of package ibm-power-repo-lastest.noarch.rpm or a package with similar contents, as defined by variable __sap_hana_preconfigure_ibm_power_repo_url in vars/RedHat_7.yml and vars/RedHat_8.yml.
+You can replace it by your own URL by setting this variable to a different URL.
+```yaml
+sap_hana_preconfigure_ibm_power_repo_url
+```
+
 ### How to behave if reboot is required
 The following variable will ensure that the role will fail if a reboot is required, if undefined or set to `yes`, which is also the default. Rebooting the managed node can be done in the playbook which is calling this role. By setting the variable to `no`, the role will not fail if a reboot is required.
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,8 +73,8 @@ sap_hana_preconfigure_update: no
 
 sap_hana_preconfigure_kernel_parameters: "{{ __sap_hana_preconfigure_kernel_parameters_default }}"
 
-# sap_hana_preconfigure_ibm_power_repo_url: "{{ __sap_hana_preconfigure_ibm_power_repo_url }}"
-sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-3.0.0-19.noarch.rpm'
+# sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-3.0.0-19.noarch.rpm'
+sap_hana_preconfigure_ibm_power_repo_url: "{{ __sap_hana_preconfigure_ibm_power_repo_url }}"
 
 #### The following parameters are for PPC LE only
 ## add a list of interfaces where MTU size will be set to 9000

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,6 +73,8 @@ sap_hana_preconfigure_update: no
 
 sap_hana_preconfigure_kernel_parameters: "{{ __sap_hana_preconfigure_kernel_parameters_default }}"
 
+sap_hana_preconfigure_add_ibm_power_repo: yes
+
 # sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-3.0.0-19.noarch.rpm'
 sap_hana_preconfigure_ibm_power_repo_url: "{{ __sap_hana_preconfigure_ibm_power_repo_url }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,6 +73,9 @@ sap_hana_preconfigure_update: no
 
 sap_hana_preconfigure_kernel_parameters: "{{ __sap_hana_preconfigure_kernel_parameters_default }}"
 
+# sap_hana_preconfigure_ibm_power_repo_url: "{{ __sap_hana_preconfigure_ibm_power_repo_url }}"
+sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-3.0.0-19.noarch.rpm'
+
 #### The following parameters are for PPC LE only
 ## add a list of interfaces where MTU size will be set to 9000
 ## defaults to empty

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,7 +19,7 @@
   command: grub2-mkconfig -o /boot/grub2/grub.cfg
   register: command_result
   listen: "Regenerate grub2 conf handler"
-  when: 
+  when:
     - not efi_exists.stat.exists
     - sap_hana_preconfigure_run_grub2_mkconfig|d(true)
 

--- a/tasks/RedHat/configuration.yml
+++ b/tasks/RedHat/configuration.yml
@@ -5,7 +5,7 @@
 #    verbosity: "{{ debuglevel }}"
 #
 - name: list of required SAP Notes
-  debug: 
+  debug:
     var: __sap_hana_preconfigure_sapnotes | difference([''])
 
 # We want to disable firewalld, so we need to check if firewalld is installed
@@ -13,10 +13,10 @@
   package_facts:
     manager: auto
 
-- name: include configuration actions for required sapnotes 
+- name: include configuration actions for required sapnotes
   include_tasks: "sapnote/{{ item }}.yml"
   with_items: "{{ __sap_hana_preconfigure_sapnotes | difference(['']) }}"
-     
+
 - include_tasks: "{{ './' + ansible_distribution + '_' + ansible_distribution_major_version + '/recommendations.yml' }}"
 
 ...

--- a/tasks/RedHat/configuration.yml
+++ b/tasks/RedHat/configuration.yml
@@ -17,6 +17,6 @@
   include_tasks: "sapnote/{{ item }}.yml"
   with_items: "{{ __sap_hana_preconfigure_sapnotes | difference(['']) }}"
      
-- include: "{{ './' + ansible_distribution + '_' + ansible_distribution_major_version + '/recommendations.yml' }}"
+- include_tasks: "{{ './' + ansible_distribution + '_' + ansible_distribution_major_version + '/recommendations.yml' }}"
 
 ...

--- a/tasks/RedHat/generic/configure-tuned.yml
+++ b/tasks/RedHat/generic/configure-tuned.yml
@@ -22,7 +22,7 @@
       block:
         - name: Switch to tuned profile sap-hana if not currently active
           command: /usr/sbin/tuned-adm profile sap-hana
-        
+
         - name: Show active tuned profile
           command: bash -lc "/usr/sbin/tuned-adm active | grep ":" | cut -d ":" -f 2 | awk '{$1=$1;print}'"
           register: new_profile
@@ -67,7 +67,7 @@
       block:
         - name: Switch to tuned profiles sap-hana sap-hana-ppc64le if not currently active
           command: /usr/sbin/tuned-adm profile sap-hana sap-hana-ppc64le
-        
+
         - name: Show active tuned profile
           command: bash -lc "/usr/sbin/tuned-adm active | grep ":" | cut -d ":" -f 2 | awk '{$1=$1;print}'"
           register: new_profile_ppc64le

--- a/tasks/RedHat/generic/disable-coredumps.yml
+++ b/tasks/RedHat/generic/disable-coredumps.yml
@@ -4,11 +4,11 @@
     msg: "imported RedHat/generic/disable-coredumps.yml"
 
 - name: disable core file creation for all users
-  pam_limits: 
+  pam_limits:
     dest: /etc/security/limits.d/99-sap.conf
-    domain: "*" 
-    limit_item: core 
-    limit_type: "{{ line_item }}" 
+    domain: "*"
+    limit_item: core
+    limit_type: "{{ line_item }}"
     value: '0'
   with_items:
     - hard

--- a/tasks/RedHat/installation.yml
+++ b/tasks/RedHat/installation.yml
@@ -21,7 +21,7 @@
       state: present
 
   when: sap_hana_preconfigure_enable_sap_hana_repos
-  
+
 - name: Detect if the minor RHEL release is set
   shell: subscription-manager release --show | awk '{print $NF}'
   register: subscription_manager_release_result
@@ -131,7 +131,7 @@
     when: sap_hana_preconfigure_fact_minpkglist | d([])
 #    when: not ( sap_hana_preconfigure_fact_minpkglist == [ "" ] )
 
-  when: 
+  when:
     - sap_hana_preconfigure_min_package_check|bool
     - __sap_hana_preconfigure_min_pkgs | d([])
 #    - not( (__sap_hana_preconfigure_min_pkgs is undefined) or (__sap_hana_preconfigure_min_pkgs is none) or (__sap_hana_preconfigure_min_pkgs | trim == '') ) 

--- a/tasks/RedHat/installation.yml
+++ b/tasks/RedHat/installation.yml
@@ -59,28 +59,37 @@
 
 ### If this task fails, you need to enable the IBM PowerTools repository
 ### see https://www14.software.ibm.com/support/customercare/sas/f/lopdiags/home.html for details
-##
-### # yum -y install http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm
-### # /opt/ibm/lop/configure
-### # yum -y install ibm-power-managed-rhel7
-###
-- name: Install IBM Tools 
+
+- name: Install the ibm-power-repo package
+  yum:
+    name: "{{ sap_hana_preconfigure_ibm_power_repo_url }}"
+    state: present
+  when: ansible_architecture == "ppc64le"
+
+- name: Accept the license for the IBM tools
+  shell: |
+    MORE=+1000 /opt/ibm/lop/configure <<-EOF
+    y
+    EOF
+  when: ansible_architecture == "ppc64le"
+
+- name: Install IBM tools
   package:
     state: latest
     name: "{{ __sap_hana_preconfigure_required_ppc64le }}"
-  when: ansible_architecture == "ppc64le" 
+  when: ansible_architecture == "ppc64le"
 
-- name: Get status of installed IBM Tools
+- name: Get status of installed IBM tools
   yum:
     name: "{{ __sap_hana_preconfigure_required_ppc64le }}"
   register: ibm_result
   ignore_errors: True
   changed_when: false
-  when: ansible_architecture == "ppc64le" 
+  when: ansible_architecture == "ppc64le"
 
 - debug:
     var: ibm_result.results
-  when: ansible_architecture == "ppc64le" 
+  when: ansible_architecture == "ppc64le"
 
 - name: Ensure minimum packages are installed
   block:

--- a/tasks/RedHat/installation.yml
+++ b/tasks/RedHat/installation.yml
@@ -64,14 +64,18 @@
   yum:
     name: "{{ sap_hana_preconfigure_ibm_power_repo_url }}"
     state: present
-  when: ansible_architecture == "ppc64le"
+  when:
+    - ansible_architecture == "ppc64le"
+    - sap_hana_preconfigure_add_ibm_power_repo|d(true)
 
 - name: Accept the license for the IBM tools
   shell: |
     MORE=+1000 /opt/ibm/lop/configure <<-EOF
     y
     EOF
-  when: ansible_architecture == "ppc64le"
+  when:
+    - ansible_architecture == "ppc64le"
+    - sap_hana_preconfigure_add_ibm_power_repo|d(true)
 
 - name: Install IBM tools
   package:

--- a/tasks/RedHat_7/recommendations.yml
+++ b/tasks/RedHat_7/recommendations.yml
@@ -3,11 +3,11 @@
 ## This creates the SAP Users in case you define them in your playbook
 ## This has been done for providers who want to create the SAP users before handing 
 ## over the image to clients
-- name: ensure sapadm group and sapadm user is created 
+- name: ensure sapadm group and sapadm user is created
   block:
-    - name: ensure sapdm user exists      
-      group: 
-        name: sapsys 
+    - name: ensure sapdm user exists
+      group:
+        name: sapsys
         gid: "{{ sap_sapsys_gid }}"
     - name: ensure sapadm user exists
       user:
@@ -19,7 +19,7 @@
     - sap_sapsys_gid is defined
     - sap_sapadm_uid is defined
     - sap_sapadm_pw_clear is defined
-    
+
 ### Disable tempfile handling, otherwise things are gone after reboot
 #     already in sap-preconfigure, sapnote/2002167/06-additional-notes-for-installing-sap-systems.yml
 # - name: disable temp file handling for SAP applications

--- a/tasks/RedHat_8/recommendations.yml
+++ b/tasks/RedHat_8/recommendations.yml
@@ -3,11 +3,11 @@
 ## Most of this is described in SAP Note 2009879
 
 ## TODO: Next task should be moved to sap-deploy, or sap-hostagent install !
-- name: ensure sapsys group and sapadm user are created 
+- name: ensure sapsys group and sapadm user are created
   block:
-    - name: ensure sapsys group exists      
-      group: 
-        name: sapsys 
+    - name: ensure sapsys group exists
+      group:
+        name: sapsys
         gid: "{{ sap_sapsys_gid }}"
     - name: ensure sapadm user exists
       user:
@@ -20,7 +20,6 @@
     - sap_sapsys_gid is defined
     - sap_sapadm_uid is defined
     - sap_sapadm_pw_clear is defined
-    
 
 ### Firewall Settings can only be done if SAP instance ID is known, 
 ### otherwise disable firewall

--- a/tasks/SLES/configuration.yml
+++ b/tasks/SLES/configuration.yml
@@ -5,13 +5,13 @@
 #    verbosity: "{{ debuglevel }}"
 #
 - name: list of required SAP Notes
-  debug: 
+  debug:
     var: __sap_hana_preconfigure_sapnotes | difference([''])
 
-- name: include configuration actions for required sapnotes 
+- name: include configuration actions for required sapnotes
   include_tasks: "sapnotes/{{ item }}/configuration.yml"
   with_items: "{{ __sap_hana_preconfigure_sapnotes | difference(['']) }}"
-     
+
 - include_tasks: "{{ './' + ansible_distribution + ansible_distribution_major_version + '/recommendations.yml' }}"
 
 ...

--- a/tasks/SLES/configuration.yml
+++ b/tasks/SLES/configuration.yml
@@ -12,6 +12,6 @@
   include_tasks: "sapnotes/{{ item }}/configuration.yml"
   with_items: "{{ __sap_hana_preconfigure_sapnotes | difference(['']) }}"
      
-- include: "{{ './' + ansible_distribution + ansible_distribution_major_version + '/recommendations.yml' }}"
+- include_tasks: "{{ './' + ansible_distribution + ansible_distribution_major_version + '/recommendations.yml' }}"
 
 ...

--- a/tasks/SLES/installation.yml
+++ b/tasks/SLES/installation.yml
@@ -5,11 +5,11 @@
 #    verbosity: "{{ debuglevel }}"
 #
 - name: list of required SAP Notes
-  debug: 
+  debug:
     var: __sap_hana_preconfigure_sapnotes | difference([''])
 
-- name: include configuration actions for required sapnotes 
+- name: include configuration actions for required sapnotes
   include_tasks: "tasks/sapnote/{{ item }}/installation.yml"
   with_items: "{{ __sap_hana_preconfigure_sapnotes | difference(['']) }}"
-     
+
 ...

--- a/tasks/SLES15/recommendations.yml
+++ b/tasks/SLES15/recommendations.yml
@@ -1,12 +1,11 @@
 ---
 
-
 ## TODO: Next task should be moved to sap-deploy, or sap-hostagent install !
-- name: ensure sapadm group and sapadm user is created 
+- name: ensure sapadm group and sapadm user is created
   block:
-          - name: ensure sapadm user exists      
-            group: 
-              name: sapsys 
+          - name: ensure sapadm user exists
+            group:
+              name: sapsys
               gid: "{{ sap_sapsys_gid }}"
           - name: ensure sapadm user exists
             user:
@@ -18,6 +17,5 @@
     - sap_sapsys_gid is defined
     - sap_sapadm_uid is defined
     - sap_sapadm_pw_clear is defined
-    
 
 ...

--- a/tasks/sapnote/1275776/configuration.yml
+++ b/tasks/sapnote/1275776/configuration.yml
@@ -14,7 +14,7 @@
 
 - name: "1275776 - Configuration saptune sap note 1275776"
   command: "saptune note apply 1275776"
-    
+
 - name: "1275776 - Configuration saptune sap note 1984787"
   command: "saptune note apply 1984787"
 

--- a/tasks/sapnote/1944799/installation.yml
+++ b/tasks/sapnote/1944799/installation.yml
@@ -25,10 +25,9 @@
 - name: "1944799 - PDF 8.1 Package List Packages"
   zypper:
     name: "{{ packages }}"
-    type: package 
+    type: package
   vars:
     packages:
       - libssh2-1
       - libopenssl1_0_0
 ...
-    

--- a/tasks/sapnote/2009879_7.yml
+++ b/tasks/sapnote/2009879_7.yml
@@ -25,7 +25,7 @@
     with_items:
       - { src: 'libssl.so.1.0.1e', dest: 'libssl.so.1.0.1' }
       - { src: 'libcrypto.so.1.0.1e', dest: 'libcrypto.so.1.0.1' }
-    when: 
+    when:
        ( ansible_distribution_version  == '7.2' )
     loop_control:
       loop_var: line_item
@@ -35,7 +35,7 @@
     with_items:
       - { src: 'libssl.so.10', dest: 'libssl.so.1.0.1' }
       - { src: 'libcrypto.so.10', dest: 'libcrypto.so.1.0.1' }
-    when: 
+    when:
        ( ansible_distribution_version  != '7.2' )
     loop_control:
       loop_var: line_item

--- a/tasks/sapnote/2013638.yml
+++ b/tasks/sapnote/2013638.yml
@@ -1,8 +1,7 @@
 ---
 # OS RELEASE: RHEL 6.5
-
-
-fail:
-        msg: "RHEL 6.5 is out of maintenance\nPlease upgrade to RHEL 6.7 at least"
+#
+- fail:
+    msg: "RHEL 6.5 is out of maintenance.\nPlease upgrade to RHEL 6.7 at least"
 
 ...

--- a/tasks/sapnote/2055470.yml
+++ b/tasks/sapnote/2055470.yml
@@ -36,7 +36,7 @@
   when: not( (sap_hana_preconfigure_ppcle_tso_if is undefined) or (sap_hana_preconfigure_ppcle_tso_if is none) or (sap_hana_preconfigure_ppcle_tso_if | trim == '') )
   loop_control:
     loop_var: line_item
-  
+
 - name: add largesend parameter
   sysctl:
     sysctl_file: /etc/sysctl.d/ibm_largesend.conf

--- a/tasks/sapnote/2136965.yml
+++ b/tasks/sapnote/2136965.yml
@@ -4,7 +4,7 @@
 # https://launchpad.support.sap.com/#/notes/2136965
 
 
-fail:
-        msg: "RHEL 6.6 is out of maintenance\nPlease upgrade to RHEL 6.7 at least"
+- fail:
+    msg: "RHEL 6.6 is out of maintenance\nPlease upgrade to RHEL 6.7 at least"
 
 ...

--- a/tasks/sapnote/2247020.yml
+++ b/tasks/sapnote/2247020.yml
@@ -1,7 +1,7 @@
 ---
 # OS RELEASE: RHEL 6.7
 
-fail:
-        msg: "RHEL 6.7 is not implemented yet"
+- fail:
+    msg: "RHEL 6.7 is not implemented yet"
 
 ...

--- a/tasks/sapnote/2382421.yml
+++ b/tasks/sapnote/2382421.yml
@@ -3,10 +3,10 @@
 # SAP Note: 2382421 - Optimizing the Network Configuration on HANA- and OS-Level
 #
 - name: setting kernel tunables as in SAP NOTE 2382421
-  sysctl: 
+  sysctl:
     sysctl_file: "{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}"
     name: "{{ line_item.name }}"
-    value: "{{ line_item.value }}" 
+    value: "{{ line_item.value }}"
     state: present
     sysctl_set: yes
     reload: yes

--- a/tasks/sapnote/2578899/configuration.yml
+++ b/tasks/sapnote/2578899/configuration.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: 2588899 - I/O scheduler 
+- name: 2588899 - I/O scheduler
   lineinfile:
     path: /etc/default/grub
     backup: yes

--- a/tasks/sapnote/2578899/installation.yml
+++ b/tasks/sapnote/2578899/installation.yml
@@ -10,7 +10,7 @@
       - libopenssl1_0_0
 
 
-- name: 2578899 - sysstat - monitoring data 
+- name: 2578899 - sysstat - monitoring data
   package:
     name: "sysstat"
 

--- a/tasks/sapnote/2684254/configuration.yml
+++ b/tasks/sapnote/2684254/configuration.yml
@@ -1,10 +1,10 @@
 ---
-- name: 2684254 - Increase UserTasksMax 
+- name: 2684254 - Increase UserTasksMax
   copy:
     dest: "/etc/systemd/logind.conf.d/sap.conf"
     content: |
       [Login]
-      UserTasksMax=infinity 
+      UserTasksMax=infinity
 #- name: Turn off auto-numa balancing
 #  sysctl:
 #          sysctl_file: /etc/sysctl.d/sap_hana.conf

--- a/tasks/sapnote/2684254/installation.yml
+++ b/tasks/sapnote/2684254/installation.yml
@@ -8,7 +8,7 @@
   package:
     name: "{{ packages }}"
   vars:
-    packages: 
+    packages:
       - libopenssl1_0_0
       - libssh2-1
 

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -120,7 +120,7 @@ __sap_hana_preconfigure_packages:
 # libtool-ltdl: See https://answers.sap.com/questions/476177/hana-db-installation-ended-with-exit-code-127.html
 # This is required since HANA 2 SPS 03, and so we always install it.
 
-__sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-lastest.noarch.rpm'
+__sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'
 
 # As per https://www14.software.ibm.com/support/customercare/sas/f/lopdiags/home.html :
 __sap_hana_preconfigure_required_ppc64le:

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -21,36 +21,60 @@ __sap_hana_preconfigure_sapnotes:
 # If variable __sap_hana_preconfigure_min_packages_VERSION is not defined,
 # variable __sap_hana_preconfigure_min_pkgs will be undefined as well.
 
-__sap_hana_preconfigure_min_packages_7_2:
+__sap_hana_preconfigure_min_packages_7_2_x86_64:
   - [ 'kernel' , '3.10.0-327.62.4.el7' ]
   - [ 'systemd' , '219-19.el7_2.4' ]
 
-__sap_hana_preconfigure_min_packages_7_3:
+__sap_hana_preconfigure_min_packages_7_2_ppc64le:
+  - [ 'kernel' , '3.10.0-327.62.4.el7' ]
+  - [ 'systemd' , '219-19.el7_2.4' ]
+
+__sap_hana_preconfigure_min_packages_7_3_x86_64:
   - [ 'kernel' , '3.10.0-514.36.5.el7' ]
   - [ 'glibc' , '2.17-157.el7_3.5' ]
   - [ 'tuned-profiles-sap-hana' , '2.7.1-3.el7_3.3' ]
 
-__sap_hana_preconfigure_min_packages_7_4:
+__sap_hana_preconfigure_min_packages_7_3_ppc64le:
+  - [ 'kernel' , '3.10.0-514.36.5.el7' ]
+  - [ 'glibc' , '2.17-157.el7_3.5' ]
+  - [ 'tuned-profiles-sap-hana' , '2.7.1-3.el7_3.3' ]
+
+# Attention: SAP note 2812427 requires more recent package kernel-3.10.0-693.58.1, covered by role sap-preconfigure
+__sap_hana_preconfigure_min_packages_7_4_x86_64:
   - [ 'kernel' , '3.10.0-693.11.6.el7' ]
   - [ 'tuned-profiles-sap-hana' , '2.8.0-5.el7_4.2' ]
 
-# SAP note 2812427:
-__sap_hana_preconfigure_min_packages_7_5:
-  - [ 'kernel' , '3.10.0-862.41.1.el7' ]
+__sap_hana_preconfigure_min_packages_7_4_ppc64le:
+  - [ 'kernel' , '3.10.0-693.11.6.el7' ]
+  - [ 'tuned-profiles-sap-hana' , '2.8.0-5.el7_4.2' ]
 
-# SAP note 2812427:
-__sap_hana_preconfigure_min_packages_7_6:
-  - [ 'kernel' , '3.10.0-957.27.4.el7' ]
+__sap_hana_preconfigure_min_packages_7_5_x86_64:
 
-# SAP note 2812427:
-__sap_hana_preconfigure_min_packages_7_7:
-  - [ 'kernel' , '3.10.0-1062.1.1.el7' ]
+__sap_hana_preconfigure_min_packages_7_5_ppc64le:
 
-__sap_hana_preconfigure_min_packages_7_8:
+# Attention: SAP note 2812427 requires more recent package kernel-3.10.0-957.35.1, covered by role sap-preconfigure
+__sap_hana_preconfigure_min_packages_7_6_x86_64:
+  - [ 'kernel' , '3.10.0-957.1.3.el7' ]
 
-__sap_hana_preconfigure_min_packages_7_9:
+__sap_hana_preconfigure_min_packages_7_6_ppc64le:
+  - [ 'kernel' , '3.10.0-957.1.3.el7' ]
 
-__sap_hana_preconfigure_min_pkgs: "{{ lookup('vars','__sap_hana_preconfigure_min_packages_' + ansible_distribution_version|string|replace (\".\", \"_\") ) }}"
+# SAP note 2292690:
+__sap_hana_preconfigure_min_packages_7_7_x86_64:
+  - [ 'kernel' , '3.10.0-1062.21.1.el7' ]
+
+__sap_hana_preconfigure_min_packages_7_7_ppc64le:
+  - [ 'kernel' , '3.10.0-1062.26.1.el7' ]
+
+__sap_hana_preconfigure_min_packages_7_8_x86_64:
+
+__sap_hana_preconfigure_min_packages_7_8_ppc64le:
+
+__sap_hana_preconfigure_min_packages_7_9_x86_64:
+
+__sap_hana_preconfigure_min_packages_7_9_ppc64le:
+
+__sap_hana_preconfigure_min_pkgs: "{{ lookup('vars','__sap_hana_preconfigure_min_packages_' + ansible_distribution_version|string|replace (\".\", \"_\") + '_' + ansible_architecture|string) }}"
 
 __sap_hana_preconfigure_packages:
 # SAP note 2009879:

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -120,6 +120,8 @@ __sap_hana_preconfigure_packages:
 # libtool-ltdl: See https://answers.sap.com/questions/476177/hana-db-installation-ended-with-exit-code-127.html
 # This is required since HANA 2 SPS 03, and so we always install it.
 
+__sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-lastest.noarch.rpm'
+
 # As per https://www14.software.ibm.com/support/customercare/sas/f/lopdiags/home.html :
 __sap_hana_preconfigure_required_ppc64le:
   - librtas

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -25,11 +25,13 @@ __sap_hana_preconfigure_sapnotes:
 # variable __sap_hana_preconfigure_min_pkgs will be undefined as well.
 
 # Minimum required package levels for RHEL 8.0:
+# Attention: SAP note 2812427 requires more recent package kernel-4.18.0-80.15.1.el8_0 also for x86_64, covered by role sap-preconfigure
 __sap_hana_preconfigure_min_packages_8_0_x86_64:
 
 __sap_hana_preconfigure_min_packages_8_0_ppc64le:
   - [ 'kernel' , '4.18.0-80.15.1.el8_0' ]
 
+# Minimum required package levels for RHEL 8.1:
 __sap_hana_preconfigure_min_packages_8_1_x86_64:
   - [ 'kernel' , '4.18.0-147.5.1.el8_1' ]
 

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -103,6 +103,8 @@ __sap_hana_preconfigure_packages:
 # https://public.dhe.ibm.com/software/server/POWER/Linux/yum/OSS/RHEL/8/ppc64le/
 # To install the packages, you need to create an appropriate repofile 
 # or clone this repository (e.g. with Satellite product)
+__sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-lastest.noarch.rpm'
+
 __sap_hana_preconfigure_required_ppc64le:
   - librtas
   - src

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -103,7 +103,7 @@ __sap_hana_preconfigure_packages:
 # https://public.dhe.ibm.com/software/server/POWER/Linux/yum/OSS/RHEL/8/ppc64le/
 # To install the packages, you need to create an appropriate repofile 
 # or clone this repository (e.g. with Satellite product)
-__sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-lastest.noarch.rpm'
+__sap_hana_preconfigure_ibm_power_repo_url: 'http://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'
 
 __sap_hana_preconfigure_required_ppc64le:
   - librtas


### PR DESCRIPTION
#109: Support for RHEL 7.7
#110: Minimum kernel versions from SAP note 2812427 need to be moved to sap-preconfigure - see also sap-preconfigure issue #89
#111: Add support for IBM service and productivity tools for Power
#112: include module is/will be deprecated and is causing ansible-lint to fail
#113: ansible-lint failing with "AttributeError: 'AnsibleUnicode' object has no attribute 'get'"
#114: ansible-lint: remove all trailing whitespace warnings
#116: add an option for not adding the repo for IBM service and productivity tools for Power
