### PR TITLE
use services_state module instead of command

### DIFF
--- a/tasks/RedHat/generic/disable-abrt-ccpp.yml
+++ b/tasks/RedHat/generic/disable-abrt-ccpp.yml
@@ -22,12 +22,17 @@
         enabled: no
       when: not abrt_ccpp_check.changed
 
+    - name: Collect facts about system services
+      service_facts:
+      register: services_state
+
     - name: Get status of abrt-ccpp
-      command: bash -lc "systemctl status abrt-ccpp"
-      register: command_result
-      ignore_errors: true
-    - debug:
-        var: command_result.stdout_lines, command_result.stderr_lines
+      debug:
+        msg: >
+             abrt-ccpp is
+             '{{ services_state.ansible_facts.services["abrt-ccpp.service"].state }}'
+             and
+             '{{ services_state.ansible_facts.services["abrt-ccpp.service"].status }}'
   when: not abrt_ccpp_check.changed
 
 ...

--- a/tasks/RedHat/generic/disable-abrt.yml
+++ b/tasks/RedHat/generic/disable-abrt.yml
@@ -22,12 +22,17 @@
         enabled: no
       when: not abrt_check.changed
 
-    - name: Get status of abrt
-      command: bash -lc "systemctl status abrtd"
-      register: command_result
-      ignore_errors: true
-    - debug:
-        var: command_result.stdout_lines, command_result.stderr_lines
+    - name: Collect facts about system services
+      service_facts:
+      register: services_state
+
+    - name: Get status of abrtd
+      debug:
+        msg: >
+             abrtd is
+             '{{ services_state.ansible_facts.services["abrtd.service"].state }}'
+             and
+             '{{ services_state.ansible_facts.services["abrtd.service"].status }}'
   when: not abrt_check.changed
 
 ...

--- a/tasks/RedHat/generic/disable-firewall.yml
+++ b/tasks/RedHat/generic/disable-firewall.yml
@@ -3,22 +3,36 @@
 - debug:
     msg: "imported RedHat/generic/configure-firewall.yml"
 
-- name: Stop and disable service firewalld
-  systemd:
-    name: firewalld
-    state: stopped
-    enabled: no
-  when: "'firewalld' in ansible_facts.packages"
+- name: Gather package facts
+  package_facts:
+    manager: auto
 
-- name: Collect facts about system services
-  service_facts:
-  register: services_state
+- name: Configure firewall
+  block:
 
-- name: Get status of firewalld
-  debug:
-    msg: >
-         firewalld is
-         '{{ services_state.ansible_facts.services["firewalld.service"].state }}'
-         and
-         '{{ services_state.ansible_facts.services["firewalld.service"].status }}'
+    - name: Stop and disable service firewalld
+      systemd:
+        name: firewalld
+        state: stopped
+        enabled: no
+
+    - name: Collect facts about system services
+      service_facts:
+      register: services_state
+
+    - name: Get status of firewalld
+      debug:
+        msg: >
+             firewalld is
+             '{{ services_state.ansible_facts.services["firewalld.service"].state }}'
+             and
+             '{{ services_state.ansible_facts.services["firewalld.service"].status }}'
+  rescue:
+
+    - name: Report if firewalld not installed
+      fail:
+        msg: "Firewalld is not installed"
+      when: "'firewalld' not in ansible_facts.packages"
+      ignore_errors: true
+
 ...

--- a/tasks/RedHat/generic/disable-firewall.yml
+++ b/tasks/RedHat/generic/disable-firewall.yml
@@ -10,11 +10,15 @@
     enabled: no
   when: "'firewalld' in ansible_facts.packages"
 
-- name: Get status of firewalld
-  command: bash -lc "systemctl status firewalld"
-  register: command_result
-  ignore_errors: True
-- debug:
-    var: command_result.stdout_lines, command_result.stderr_lines
+- name: Collect facts about system services
+  service_facts:
+  register: services_state
 
+- name: Get status of firewalld
+  debug:
+    msg: >
+         firewalld is
+         '{{ services_state.ansible_facts.services["firewalld.service"].state }}'
+         and
+         '{{ services_state.ansible_facts.services["firewalld.service"].status }}'
 ...

--- a/tasks/RedHat/generic/turn-off-auto-numa-balancing.yml
+++ b/tasks/RedHat/generic/turn-off-auto-numa-balancing.yml
@@ -24,12 +24,17 @@
             enabled: no
           when: not numad_check.changed
 
-        - name: Get status of numad
-          command: bash -lc "systemctl status numad"
-          register: command_result
-          ignore_errors: true
-        - debug:
-            var: command_result.stdout_lines, command_result.stderr_lines
+    - name: Collect facts about system services
+      service_facts:
+      register: services_state
+
+    - name: Get status of numad
+      debug:
+        msg: >
+             numad is
+             '{{ services_state.ansible_facts.services["numad.service"].state }}'
+             and
+             '{{ services_state.ansible_facts.services["numad.service"].status }}'
       when: not numad_check.changed
 
   when:


### PR DESCRIPTION
Ansible has a built-in module `service_facts` which returns service state information fact data for various service management utilities. It can be used instead of `command: bash -lc "systemctl status <service>"` + `debug` modules. 

Also, that bash command returns non zero code, which results in error print in red even if the `ignore_errors` flag is used. It may disturb a user unnecessarily. `service_facts` will print it in green. 

Compare two outputs: 
Before this PR:
```
TASK [Stop and disable service firewalld] ********************************************************************************
changed: [localhost]

TASK [Get status of firewalld] *******************************************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["bash", "-lc", "systemctl status firewalld"], "delta": "0:00:00.016379", "end": "2020-10-14 15:52:59.913780", "msg": "non-zero return code", "rc": 3, "start": "2020-10-14 15:52:59.897401", "stderr": "", "stderr_lines": [], "stdout": "● firewalld.service - firewalld - dynamic firewall daemon\n   Loaded: loaded (/usr/lib/systemd/system/firewalld.service; disabled; vendor preset: enabled)\n   Active: inactive (dead)\n     Docs: man:firewalld(1)\n\nOct 14 13:23:20 ip-10-0-1-135 systemd[1]: Stopping firewalld - dynamic firewall daemon...\nOct 14 13:23:21 ip-10-0-1-135 systemd[1]: Stopped firewalld - dynamic firewall daemon.\nOct 14 13:53:42 ip-10-0-1-135 systemd[1]: Starting firewalld - dynamic firewall daemon...\nOct 14 13:53:42 ip-10-0-1-135 systemd[1]: Started firewalld - dynamic firewall daemon.\nOct 14 13:53:56 ip-10-0-1-135 systemd[1]: Stopping firewalld - dynamic firewall daemon...\nOct 14 13:53:57 ip-10-0-1-135 systemd[1]: Stopped firewalld - dynamic firewall daemon.\nOct 14 15:52:15 ip-10-0-1-135 systemd[1]: Starting firewalld - dynamic firewall daemon...\nOct 14 15:52:15 ip-10-0-1-135 systemd[1]: Started firewalld - dynamic firewall daemon.\nOct 14 15:52:58 ip-10-0-1-135 systemd[1]: Stopping firewalld - dynamic firewall daemon...\nOct 14 15:52:59 ip-10-0-1-135 systemd[1]: Stopped firewalld - dynamic firewall daemon.", "stdout_lines": ["● firewalld.service - firewalld - dynamic firewall daemon", "   Loaded: loaded (/usr/lib/systemd/system/firewalld.service; disabled; vendor preset: enabled)", "   Active: inactive (dead)", "     Docs: man:firewalld(1)", "", "Oct 14 13:23:20 ip-10-0-1-135 systemd[1]: Stopping firewalld - dynamic firewall daemon...", "Oct 14 13:23:21 ip-10-0-1-135 systemd[1]: Stopped firewalld - dynamic firewall daemon.", "Oct 14 13:53:42 ip-10-0-1-135 systemd[1]: Starting firewalld - dynamic firewall daemon...", "Oct 14 13:53:42 ip-10-0-1-135 systemd[1]: Started firewalld - dynamic firewall daemon.", "Oct 14 13:53:56 ip-10-0-1-135 systemd[1]: Stopping firewalld - dynamic firewall daemon...", "Oct 14 13:53:57 ip-10-0-1-135 systemd[1]: Stopped firewalld - dynamic firewall daemon.", "Oct 14 15:52:15 ip-10-0-1-135 systemd[1]: Starting firewalld - dynamic firewall daemon...", "Oct 14 15:52:15 ip-10-0-1-135 systemd[1]: Started firewalld - dynamic firewall daemon.", "Oct 14 15:52:58 ip-10-0-1-135 systemd[1]: Stopping firewalld - dynamic firewall daemon...", "Oct 14 15:52:59 ip-10-0-1-135 systemd[1]: Stopped firewalld - dynamic firewall daemon."]}
...ignoring

TASK [debug] *************************************************************************************************************
ok: [localhost] => {
    "command_result.stdout_lines, command_result.stderr_lines": "([u'\\u25cf firewalld.service - firewalld - dynamic firewall daemon', u'   Loaded: loaded (/usr/lib/systemd/system/firewalld.service; disabled; vendor preset: enabled)', u'   Active: inactive (dead)', u'     Docs: man:firewalld(1)', u'', u'Oct 14 13:23:20 ip-10-0-1-135 systemd[1]: Stopping firewalld - dynamic firewall daemon...', u'Oct 14 13:23:21 ip-10-0-1-135 systemd[1]: Stopped firewalld - dynamic firewall daemon.', u'Oct 14 13:53:42 ip-10-0-1-135 systemd[1]: Starting firewalld - dynamic firewall daemon...', u'Oct 14 13:53:42 ip-10-0-1-135 systemd[1]: Started firewalld - dynamic firewall daemon.', u'Oct 14 13:53:56 ip-10-0-1-135 systemd[1]: Stopping firewalld - dynamic firewall daemon...', u'Oct 14 13:53:57 ip-10-0-1-135 systemd[1]: Stopped firewalld - dynamic firewall daemon.', u'Oct 14 15:52:15 ip-10-0-1-135 systemd[1]: Starting firewalld - dynamic firewall daemon...', u'Oct 14 15:52:15 ip-10-0-1-135 systemd[1]: Started firewalld - dynamic firewall daemon.', u'Oct 14 15:52:58 ip-10-0-1-135 systemd[1]: Stopping firewalld - dynamic firewall daemon...', u'Oct 14 15:52:59 ip-10-0-1-135 systemd[1]: Stopped firewalld - dynamic firewall daemon.'], [])"
}

```
After this PR:
```
TASK [Collect facts about system services] ******************************************************************
ok: [localhost]

TASK [Get status of firewalld] ************************************************************************************************
ok: [localhost] => {
    "msg": "firewalld is 'inactive' and 'disabled'\n"
}

```