### PR TITLE
Raise supported Ansible version to 2.9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@ galaxy_info:
   author: Markus Koch, Thomas Bludau, Bernd Finger <bfinger@redhat.com>, Than Ngo <than@redhat.com>
   description: Configures a RHEL OS to be ready for SAP HANA installation
   license: GNU General Public License v3.0
-  min_ansible_version: 2.5
+  min_ansible_version: 2.9
   platforms:
   - name: EL
     versions: [ 6, 7, 8 ]


### PR DESCRIPTION
Bug 1989197 - drop support for Ansible 2.8
https://bugzilla.redhat.com/show_bug.cgi?id=1989197