### PR TITLE
Disable-KSM and Enable-TSX provoke unnecessary reboots 

### DIFF
--- a/tasks/RedHat/generic/disable-ksm.yml
+++ b/tasks/RedHat/generic/disable-ksm.yml
@@ -3,16 +3,17 @@
 - debug:
     msg: "imported RedHat/generic/disable-ksm.yml"
 
+- name: Get info about file /etc/init.d/boot.local
+  stat:
+    path: /etc/init.d/boot.local
+  register: __sap_hana_preconfigure_register_stat_boot_local_ksm
+
 - name: Create file /etc/init.d/boot.local if it does not exist
   file:
     path: /etc/init.d/boot.local
     state: touch
     mode: 0755
-
-- name: Get info about file /etc/init.d/boot.local
-  stat:
-    path: /etc/init.d/boot.local
-  register: __sap_hana_preconfigure_register_stat_boot_local_ksm
+  when: not __sap_hana_preconfigure_register_stat_boot_local_ksm.stat.exists
 
 - name: Disable KSM at boot time
   lineinfile:

--- a/tasks/RedHat/generic/enable-tsx.yml
+++ b/tasks/RedHat/generic/enable-tsx.yml
@@ -3,6 +3,11 @@
 - debug:
     msg: "imported RedHat/generic/enable-tsx.yml"
 
+- name: get boot command line
+  slurp:
+    src: /proc/cmdline
+  register: boot_cmd
+
 - name: Enable TSX at boot time
   command: /bin/true
   notify: __sap_hana_preconfigure_grubby_update_handler
@@ -11,4 +16,6 @@
     - ansible_distribution == 'RedHat'
     - ansible_distribution_major_version == '8'
     - __sap_hana_preconfigure_fact_ansible_distribution_minor_version|int >= 3
+    - not ( boot_cmd['content'] | b64decode | regex_findall('tsx=on') )
   tags: grubconfig
+  

--- a/tasks/RedHat/generic/enable-tsx.yml
+++ b/tasks/RedHat/generic/enable-tsx.yml
@@ -6,7 +6,7 @@
 - name: get boot command line
   slurp:
     src: /proc/cmdline
-  register: boot_cmd
+  register: __sap_hana_preconfigure_boot_cmd
 
 - name: Enable TSX at boot time
   command: /bin/true
@@ -16,6 +16,6 @@
     - ansible_distribution == 'RedHat'
     - ansible_distribution_major_version == '8'
     - __sap_hana_preconfigure_fact_ansible_distribution_minor_version|int >= 3
-    - not ( boot_cmd['content'] | b64decode | regex_findall('tsx=on') )
+    - not ( __sap_hana_preconfigure_boot_cmd['content'] | b64decode | regex_findall('tsx=on') )
   tags: grubconfig
   


### PR DESCRIPTION
In disable KSM the file `boot.local` is always changed by `touch` this is unnecessary and seems to provoke a reboot (or warning/fail depending on configuration) 

This patch reorders the `stat` task and added a conditional to said `touch` task.

Additional in enblabe-tsx the grubby task is always executed this also provokes unnecessary reboots or warnings/fails.

This patch adds a check if `tsx=on` is already part of the boot command line.